### PR TITLE
#Issue10 : Honorable Mention translation in FR

### DIFF
--- a/languages/fr.json
+++ b/languages/fr.json
@@ -18,6 +18,7 @@
 	},
 	"badges": {
 		"meteorik-nominee": "Nominé·e aux Meteoriks {{meteorik-year}}",
+		"meteorik-runnerup": "Mention honorable des Meteoriks {{meteorik-year}}", 
 		"meteorik-winner": "Lauréat·e des Meteoriks {{meteorik-year}}"
 	},
 	"meteoriks": {


### PR DESCRIPTION

> I've added support for Honorable Mentions into the [meteorik-honorable-mentions](https://github.com/lunasorcery/executable.graphics/tree/meteorik-honorable-mentions) branch, but the string badges.meteorik-runnerup needs to be translated into the other languages before I can push it live.

Traduction done. Still open question if would be better to align "des Meteoriks " or "aux Meteoriks "

---

> Additionally, since we've now had multiple Best Executable Graphics winners, the ending of meteoriks.what-are-meteoriks-p2 needs to be pluralized ("winner" -> "winners").

Already translated properly as we aligned the translation on modern gender neutral and plurialized french. So the french translation already have plural semantics.

---


Open for debate and acknowledgment from the "Academie Francophone de la Scène Démo" :D 
ping @Lia-Sae, @nnorm